### PR TITLE
修复h5模式下 canvas宽高不正确的问题

### DIFF
--- a/src/components/f2-canvas/f2-canvas.tsx
+++ b/src/components/f2-canvas/f2-canvas.tsx
@@ -92,7 +92,7 @@ export default class F2Canvas extends Component<F2CanvasPropTypes> {
   render () {
     const id = this.id;
     if (process.env.TARO_ENV === 'h5') {
-      return <canvas  ref={this.htmlCanvas.bind(this)} className={'f2-canvas ' + id}></canvas>
+      return <canvas  ref={this.htmlCanvas.bind(this)} style={{ width: this.state.width, height: this.state.height }} className={'f2-canvas ' + id}></canvas>
     }
     if (process.env.TARO_ENV !== 'h5') {
       return <Canvas style={'width: '+this.state.width+'; height:'+this.state.height}


### PR DESCRIPTION
在h5模式下 canvas没有设置宽高 将会被重置成 300 150 导致与预期不符，
我给canvas增加了style来和小程序中的样式保持一致。